### PR TITLE
upgraded Python to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.8
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Python 3.5 is going to be discontinued in September 2020, hence we need to upgrade to the latest version.

https://devguide.python.org/#status-of-python-branches